### PR TITLE
Remove Android SDK Build Tools version (27.0.3)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,6 @@ android {
     compileSdkVersion 27
 
     defaultConfig {
-        buildToolsVersion "27.0.3"
         applicationId "org.mozilla.permissionhandler"
         minSdkVersion 19
         targetSdkVersion 27

--- a/permissionhandler/build.gradle
+++ b/permissionhandler/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'com.android.library'
 android {
 
     defaultConfig {
-        buildToolsVersion "27.0.3"
         compileSdkVersion 27
         targetSdkVersion 27
         minSdkVersion 19


### PR DESCRIPTION
#8 Latest SDK built tools are used always if preferred.
Just removed that line in app/build.gradle