### PR TITLE
Upgrade material design version and use anchor view on snackbar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,3 @@ before_install:
   - echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "$ANDROID_HOME/licenses/android-sdk-license"
   - echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
   - yes | sdkmanager --update
-  - yes | sdkmanager --licenses

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(path: ':permissionhandler')
     implementation 'androidx.appcompat:appcompat:1.0.2'
-    implementation 'com.google.android.material:material:1.0.0'
+    implementation 'com.google.android.material:material:1.1.0-alpha05'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.2.0'

--- a/permissionhandler/build.gradle
+++ b/permissionhandler/build.gradle
@@ -21,7 +21,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.0.2'
-    implementation 'com.google.android.material:material:1.0.0'
+    implementation 'com.google.android.material:material:1.1.0-alpha05'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/permissionhandler/src/main/java/org/mozilla/permissionhandler/PermissionHandler.java
+++ b/permissionhandler/src/main/java/org/mozilla/permissionhandler/PermissionHandler.java
@@ -13,6 +13,8 @@ import android.os.Parcelable;
 import android.preference.PreferenceManager;
 import androidx.annotation.NonNull;
 import com.google.android.material.snackbar.Snackbar;
+
+import androidx.annotation.Nullable;
 import androidx.core.app.ActivityCompat;
 import androidx.fragment.app.Fragment;
 import androidx.core.content.ContextCompat;
@@ -176,6 +178,28 @@ public class PermissionHandler {
 
     public static Snackbar makeAskAgainSnackBar(final Fragment fragment, final View view, final int stringId) {
         return Snackbar.make(view, stringId, Snackbar.LENGTH_LONG)
+                .setAction(R.string.permission_handler_permission_dialog_setting, new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        intentOpenSettings(fragment, REQUEST_SETTINGS);
+                    }
+                });
+    }
+
+    public static Snackbar makeAskAgainSnackBar(final Activity activity, final View view, final int stringId, @Nullable final View anchorView) {
+        return Snackbar.make(view, stringId, Snackbar.LENGTH_LONG)
+                .setAnchorView(anchorView)
+                .setAction(R.string.permission_handler_permission_dialog_setting, new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        intentOpenSettings(activity, REQUEST_SETTINGS);
+                    }
+                });
+    }
+
+    public static Snackbar makeAskAgainSnackBar(final Fragment fragment, final View view, final int stringId, @Nullable final View anchorView) {
+        return Snackbar.make(view, stringId, Snackbar.LENGTH_LONG)
+                .setAnchorView(anchorView)
                 .setAction(R.string.permission_handler_permission_dialog_setting, new View.OnClickListener() {
                     @Override
                     public void onClick(View view) {


### PR DESCRIPTION
On Firefox team, we want to use setAnchorView function on snackbar. 
This function was introduced by material **1.1.0-alpha**

Ref:
https://github.com/material-components/material-components-android/commit/868e80ed6ff183cceeb9c33523bf47f72772c52a#diff-c2f93dda98a890c61a837d7df74e9890